### PR TITLE
Point to correct filename in the manifest

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -25,7 +25,7 @@
                 "styles/main.css"
             ],
             "js": [
-                "scripts/contentscript.js"
+                "scripts/_contentscript.js"
             ],
             "run_at": "document_idle",
             "all_frames": false


### PR DESCRIPTION
I needed to make this change to get the extension to load in Chrome.

It doesn't seem to actually work on my machine though 😦, but at least I can load it now!
